### PR TITLE
Removed Mozilla Japan link. Added Japan, Hong Kong, and India community link

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -63,6 +63,7 @@
 	"MOPCON" : "https://raw.githubusercontent.com/seadog007/Google-Code-In/master/5.%20Add%20some%20Taiwan%20communities/MOPCON-api.json",
 	"MOSUT" : "https://raw.githubusercontent.com/seadog007/Google-Code-In/master/5.%20Add%20some%20Taiwan%20communities/MOSUT-api.json",
 	"MOZ-HK" : "https://raw.githubusercontent.com/fossasia/fossasia-communities/master/China/MozillaHongKong-api.json",
+	"MOZ-Kerala" : "https://raw.githubusercontent.com/fossasia/fossasia-communities/master/India/MozillaKerala-api.json",
 	"MR": "https://raw.githubusercontent.com/fossasia/fossasia-communities/master/Russia/MozillaRussia-api.json",
 	"MTH": "https://raw.githubusercontent.com/fossasia/fossasia-communities/master/Thailand/MozillaThailand-api.json",
 	"MT": "https://raw.githubusercontent.com/fossasia/fossasia-communities/master/Turkey/MozillaTurkey-api.json",

--- a/directory.json
+++ b/directory.json
@@ -62,7 +62,6 @@
 	"MN": "https://raw.githubusercontent.com/fossasia/fossasia-communities/master/Nepal/MozillaNepal-api.json",
 	"MOPCON" : "https://raw.githubusercontent.com/seadog007/Google-Code-In/master/5.%20Add%20some%20Taiwan%20communities/MOPCON-api.json",
 	"MOSUT" : "https://raw.githubusercontent.com/seadog007/Google-Code-In/master/5.%20Add%20some%20Taiwan%20communities/MOSUT-api.json",
-	"MOZJP" : "https://raw.githubusercontent.com/fossasia/fossasia-communities/master/Japan/MozillaJapan-api.json",
 	"MR": "https://raw.githubusercontent.com/fossasia/fossasia-communities/master/Russia/MozillaRussia-api.json",
 	"MTH": "https://raw.githubusercontent.com/fossasia/fossasia-communities/master/Thailand/MozillaThailand-api.json",
 	"MT": "https://raw.githubusercontent.com/fossasia/fossasia-communities/master/Turkey/MozillaTurkey-api.json",
@@ -142,6 +141,7 @@
 	"klug" : "https://raw.githubusercontent.com/manastaneja/communities/master/Kaohsiung-lug",
 	"taipeilug" : "https://raw.githubusercontent.com/manastaneja/communities/master/taipei%20ossug",
 	"X-lug" : "https://raw.githubusercontent.com/manastaneja/communities/master/Xiyou%20lug",
+	"Yoko-lug" : "https://raw.githubusercontent.com/fossasia/fossasia-communities/master/Japan/YokohamaLinuxUserGroup-api.json",
 	"DAIICT" : "https://raw.githubusercontent.com/manastaneja/communities/master/DAIICT-lug",
 	"RV-lug" : "https://raw.githubusercontent.com/manastaneja/communities/master/R.V.%20LUG",
 	"srec-lug" : "https://raw.githubusercontent.com/manastaneja/communities/master/srec-lug"

--- a/directory.json
+++ b/directory.json
@@ -62,6 +62,7 @@
 	"MN": "https://raw.githubusercontent.com/fossasia/fossasia-communities/master/Nepal/MozillaNepal-api.json",
 	"MOPCON" : "https://raw.githubusercontent.com/seadog007/Google-Code-In/master/5.%20Add%20some%20Taiwan%20communities/MOPCON-api.json",
 	"MOSUT" : "https://raw.githubusercontent.com/seadog007/Google-Code-In/master/5.%20Add%20some%20Taiwan%20communities/MOSUT-api.json",
+	"MOZJP" : "https://raw.githubusercontent.com/fossasia/fossasia-communities/master/Japan/MozillaJapan-api.json",
 	"MR": "https://raw.githubusercontent.com/fossasia/fossasia-communities/master/Russia/MozillaRussia-api.json",
 	"MTH": "https://raw.githubusercontent.com/fossasia/fossasia-communities/master/Thailand/MozillaThailand-api.json",
 	"MT": "https://raw.githubusercontent.com/fossasia/fossasia-communities/master/Turkey/MozillaTurkey-api.json",

--- a/directory.json
+++ b/directory.json
@@ -62,6 +62,7 @@
 	"MN": "https://raw.githubusercontent.com/fossasia/fossasia-communities/master/Nepal/MozillaNepal-api.json",
 	"MOPCON" : "https://raw.githubusercontent.com/seadog007/Google-Code-In/master/5.%20Add%20some%20Taiwan%20communities/MOPCON-api.json",
 	"MOSUT" : "https://raw.githubusercontent.com/seadog007/Google-Code-In/master/5.%20Add%20some%20Taiwan%20communities/MOSUT-api.json",
+	"MOZ-HK" : "https://raw.githubusercontent.com/fossasia/fossasia-communities/master/China/MozillaHongKong-api.json",
 	"MR": "https://raw.githubusercontent.com/fossasia/fossasia-communities/master/Russia/MozillaRussia-api.json",
 	"MTH": "https://raw.githubusercontent.com/fossasia/fossasia-communities/master/Thailand/MozillaThailand-api.json",
 	"MT": "https://raw.githubusercontent.com/fossasia/fossasia-communities/master/Turkey/MozillaTurkey-api.json",


### PR DESCRIPTION
Added Japan link and removed my mozilla link since that wasn't a community. The link will work when https://github.com/fossasia/fossasia-communities/pull/69 is merged. 

My task is https://www.google-melange.com/gci/task/view/google/gci2014/5326906169753600