### PR TITLE
Fix broken links

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -103,7 +103,6 @@
 	"OMSKLUG": "https://raw.githubusercontent.com/fossasia/fossasia-communities/master/Russia/OmskLinuxUserGroup-api.json",
 	"OpenHackTaipei": "https://raw.githubusercontent.com/fossasia/fossasia-communities/master/Taiwan/OpenHackTaipei-api.json",
 	"OSC": "https://raw.githubusercontent.com/manastaneja/communities/master/Open%20source%20Cambodia.json",
-	"OSHK": "http://elearn.pyc.edu.hk/console/files/google/OpenSourceHongKong-api.json",
 	"OSSF": "https://raw.githubusercontent.com/seadog007/Google-Code-In/master/5.%20Add%20some%20Taiwan%20communities/OSSF(OpenFoundry)-OpenSourceSoftwareFoundry-api.json",
 	"OUGTH":"https://raw.githubusercontent.com/fossasia/fossasia-communities/master/Thailand/ORACLEUSERGROUPINTHAILAND-api.json",
 	"OVMSIG": "https://raw.githubusercontent.com/fossasia/fossasia-communities/master/India/OracleVMSIG-api.json",

--- a/directory.json
+++ b/directory.json
@@ -61,7 +61,6 @@
 	"JOZILUG": "https://raw.githubusercontent.com/fossasia/fossasia-communities/master/South%20Africa/JoziLUG-api.json",
 	"JUGI": "https://raw.githubusercontent.com/fossasia/fossasia-communities/master/Indonesia/JUGIndonesia-api.json",
 	"JUGM": "https://raw.githubusercontent.com/fossasia/fossasia-communities/master/Myanmar/joomla.json",
-	"Kaiyuanshe": "https://raw.githubusercontent.com/fossasia/fossasia-communities/master/China/Kaiyuanshe-api.json",
 	"kalug": "https://raw.githubusercontent.com/fossasia/fossasia-communities/master/Taiwan/KaohsiungLinuxUserGroup-api.json",
 	"KBUG": "https://raw.githubusercontent.com/fossasia/fossasia-communities/master/Japan/Kansai-BSDUsersGroup-api.json",
 	"KJBUG": "https://raw.githubusercontent.com/fossasia/fossasia-communities/master/Korea/KoreaJBossUserGroup-api.json",


### PR DESCRIPTION
Fix https://github.com/fossasia/directory.api.fossasia.net/issues/168

@tonyhhyip can you re-add the correct link to OSHK ?

maybe you should first add it to the [Communities](http://github.com/fossasia/fossasia-communities) then add a link here

Kaiyuanshe api was removed from the fossasia-communities repo by this https://github.com/fossasia/fossasia-communities/commit/1d822e439669b2c657d5198387b26fcccf9a3967